### PR TITLE
FS-65: Adding branch naming convention to pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,6 +4,6 @@ pattern="^FS-[0-9]+/[a-z0-9._-]+$"
 
 if ! [[ $branch_name =~ $pattern ]]; then
     echo "Branch name '$branch_name' does not follow the naming convention 'FS-<number>/<branch-name>', please rename using the following regex pattern and try again."
-    echo $pattern
+    echo -e "\e[94m$pattern\e[0m"
     exit 1
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,8 @@
+#!/bin/bash
+branch_name=$(git rev-parse --abbrev-ref HEAD)
+pattern="^FS-[0-9]+/[a-z0-9._-]+$"
+
+if ! [[ $branch_name =~ $pattern ]]; then
+  echo "Branch name '$branch_name' does not follow the naming convention 'FS-<number>/<branch-name>', please rename and try again."
+  exit 1
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,6 +3,7 @@ branch_name=$(git rev-parse --abbrev-ref HEAD)
 pattern="^FS-[0-9]+/[a-z0-9._-]+$"
 
 if ! [[ $branch_name =~ $pattern ]]; then
-  echo "Branch name '$branch_name' does not follow the naming convention 'FS-<number>/<branch-name>', please rename and try again."
-  exit 1
+    echo "Branch name '$branch_name' does not follow the naming convention 'FS-<number>/<branch-name>', please rename using the following regex pattern and try again."
+    echo $pattern
+    exit 1
 fi


### PR DESCRIPTION
## Description
Adding pre-push hook to require branches to follow naming convention `FS-<ticket-number>/<branch-name>`

![image](https://github.com/user-attachments/assets/92f68e56-4b3b-42d9-a53e-dd85852a25ad)
