### PR TITLE
FS-99 Clarify answer

### DIFF
--- a/backend/src/api/app.py
+++ b/backend/src/api/app.py
@@ -8,6 +8,7 @@ from typing import NoReturn
 from fastapi import FastAPI, HTTPException, Response, WebSocket, UploadFile
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
+from src.chat_storage_service import get_chat_message
 from src.session.file_uploads import clear_session_file_uploads
 from src.session.redis_session_middleware import reset_session
 from src.utils.graph_db_utils import populate_db
@@ -109,6 +110,17 @@ async def clear_chat():
         logger.exception(e)
         return Response(status_code=500)
 
+@app.get("/chat/{id}")
+def chat_message(id: str):
+    logger.info(f"Get chat message called with id: {id}")
+    try:
+        final_result = get_chat_message(id)
+        if final_result is None:
+            return JSONResponse(status_code=404, content=f"Message with id {id} not found")
+        return JSONResponse(status_code=200, content=final_result)
+    except Exception as e:
+        logger.exception(e)
+        return JSONResponse(status_code=500, content=chat_fail_response)
 
 @app.get("/suggestions")
 async def suggestions():

--- a/backend/src/chat_storage_service.py
+++ b/backend/src/chat_storage_service.py
@@ -1,0 +1,34 @@
+
+import json
+import logging
+from typing import TypedDict
+import redis
+
+from src.utils.json import try_parse_to_json
+from src.utils import Config
+
+class ChatResponse(TypedDict):
+    id: str
+    question:str
+    answer: str
+    reasoning: str | None
+
+logger = logging.getLogger(__name__)
+
+config = Config()
+
+redis_client = redis.Redis(host=config.redis_host, port=6379, decode_responses=True)
+
+CHAT_KEY_PREFIX = "chat_"
+
+def store_chat_message(chat:ChatResponse):
+    redis_client.set(CHAT_KEY_PREFIX + chat["id"], json.dumps(chat))
+
+
+def get_chat_message(id: str) -> ChatResponse | None:
+    value = redis_client.get(CHAT_KEY_PREFIX + id)
+    if value and isinstance(value, str):
+        parsed_session_data = try_parse_to_json(value)
+        if parsed_session_data:
+            return parsed_session_data
+    return None

--- a/backend/src/chat_storage_service.py
+++ b/backend/src/chat_storage_service.py
@@ -28,7 +28,6 @@ def store_chat_message(chat:ChatResponse):
 def get_chat_message(id: str) -> ChatResponse | None:
     value = redis_client.get(CHAT_KEY_PREFIX + id)
     if value and isinstance(value, str):
-        parsed_session_data = try_parse_to_json(value)
-        if parsed_session_data:
+        if parsed_session_data := try_parse_to_json(value):
             return parsed_session_data
     return None

--- a/backend/src/supervisors/supervisor.py
+++ b/backend/src/supervisors/supervisor.py
@@ -25,7 +25,7 @@ async def solve_all(intent_json) -> None:
             if status == "error":
                 raise Exception(answer)
         except Exception as error:
-            update_scratchpad(error=error)
+            update_scratchpad(error=str(error))
 
 
 async def solve_task(task, scratchpad, attempt=0) -> Tuple[str, str, str]:

--- a/backend/src/utils/json.py
+++ b/backend/src/utils/json.py
@@ -16,9 +16,12 @@ def try_parse_to_json(json_string: str):
         logger.error(f"Error parsing json: {error}")
         return None
 
+def handle_non_serializable(obj):
+    return f"{type(obj).__qualname__}: {str(obj)}"
+
 def try_pretty_print(obj):
     try:
-        return json.dumps(obj, indent=4)
+        return json.dumps(obj, indent=4, default=handle_non_serializable)
     except Exception as error:
-        logger.error(f"Error pretty printing json: {error}")
+        logger.error(f"Error pretty printing json: Error {error} for object {obj}")
         return None

--- a/backend/src/utils/json.py
+++ b/backend/src/utils/json.py
@@ -15,3 +15,10 @@ def try_parse_to_json(json_string: str):
     except json.JSONDecodeError as error:
         logger.error(f"Error parsing json: {error}")
         return None
+
+def try_pretty_print(obj):
+    try:
+        return json.dumps(obj, indent=4)
+    except Exception as error:
+        logger.error(f"Error pretty printing json: {error}")
+        return None

--- a/backend/tests/BDD/step_defs/test_prompts.py
+++ b/backend/tests/BDD/step_defs/test_prompts.py
@@ -37,7 +37,7 @@ def get_response(context):
 @then(parsers.parse("the response to this '{prompt}' should match the '{expected_response}'"))
 def check_response_includes_expected_response(context, prompt, expected_response):
     response = send_prompt(prompt)
-    actual_response = response.json()
+    actual_response = response.json()["answer"]
 
     try:
         expected_value = Decimal(str(expected_response).strip())
@@ -81,5 +81,5 @@ def check_response_includes_expected_response(context, prompt, expected_response
 @then(parsers.parse("the response to this '{prompt}' should give a confident answer"))
 def check_bot_response_confidence(prompt):
     response = send_prompt(prompt)
-    result = check_response_confidence(prompt, response.json())
+    result = check_response_confidence(prompt, response.json()["answer"])
     assert result["score"] == 1, "The bot response is not confident enough. \nReasoning: " + result["reasoning"]

--- a/backend/tests/chat_storage_service_test.py
+++ b/backend/tests/chat_storage_service_test.py
@@ -1,0 +1,32 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.chat_storage_service import ChatResponse, get_chat_message, store_chat_message
+
+@pytest.fixture
+def mock_redis():
+    with patch('src.chat_storage_service.redis_client') as mock_redis:
+        mock_instance = MagicMock()
+        mock_redis.return_value = mock_instance
+        yield mock_instance
+
+def test_store_chat_message(mocker, mock_redis):
+    mocker.patch('src.chat_storage_service.redis_client', mock_redis)
+
+    message = ChatResponse(id="1", question="Question", answer="Answer", reasoning="Reasoning")
+    store_chat_message(message)
+
+    mock_redis.set.assert_called_once_with("chat_1", json.dumps(message))
+
+
+def test_get_chat_message(mocker, mock_redis):
+    mocker.patch('src.chat_storage_service.redis_client', mock_redis)
+
+    message = ChatResponse(id="1", question="Question", answer="Answer", reasoning="Reasoning")
+    mock_redis.get.return_value = json.dumps(message)
+
+    value = get_chat_message("1")
+
+    assert value == message

--- a/backend/tests/utils/json_test.py
+++ b/backend/tests/utils/json_test.py
@@ -1,4 +1,5 @@
 import pytest
+from src.utils.json import try_pretty_print
 from src.utils import to_json
 
 
@@ -15,3 +16,9 @@ def test_to_json_failure():
         to_json(input)
 
     assert str(error.value) == f'Failed to interpret JSON: "{input}"'
+
+def test_try_pretty_print():
+    obj = {"key": "value", "error": Exception("some error")}
+    output = try_pretty_print(obj)
+
+    assert output == '{\n    "key": "value",\n    "error": "Exception: some error"\n}'

--- a/frontend/src/components/message.module.css
+++ b/frontend/src/components/message.module.css
@@ -1,22 +1,20 @@
 .container {
-  align-items: center;
-  display: flex;
-  flex-direction: row;
-  justify-content: left;
   border-radius: 16px;
   width: 100%;
   margin-bottom: 8px;
 }
 
+.message_container {
+  display: flex;
+}
+
 .bot {
-  align-self: flex-start;
   background-color: var(--grey-50);
   border: 1px solid var(--grey-300);
   box-sizing: border-box;
 }
 
 .user {
-  align-self: flex-start;
   background-color: var(--primary);
   box-shadow: inset 0 0 0 100vmax rgba(255, 255, 255, 0.65);
 }
@@ -25,11 +23,45 @@
   width: 40px;
   height: 40px;
   margin: 16px;
-  align-self: flex-start;
 }
 
 .messageStyle {
   margin: 24px 32px 16px 0;
   line-height: 22px;
   font-size: 16px;
+}
+
+.reasoning_header {
+  font-weight: bold;
+  font-size: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-top: 1px solid var(--grey-300);
+  padding: 0 24px 0 16px;
+  height: 40px;
+}
+
+.reasoning_header:hover {
+  background-color: var(--grey-200);
+  cursor: pointer;
+}
+
+.expandIcon {
+  width: 24px;
+  height: 24px;
+}
+
+.reasoning_header_expanded {
+  border-top: 1px solid var(--grey-500);
+
+  .expandIcon {
+    transform: rotate(90deg);
+  }
+}
+
+.reason {
+  padding: 12px 32px;
+  font-size: 16px;
+  white-space: pre-wrap;
 }

--- a/frontend/src/components/message.module.css
+++ b/frontend/src/components/message.module.css
@@ -45,6 +45,7 @@
 .reasoning_header:hover {
   background-color: var(--grey-200);
   cursor: pointer;
+  border-radius: 0 0 16px 16px;
 }
 
 .expandIcon {
@@ -58,6 +59,10 @@
   .expandIcon {
     transform: rotate(90deg);
   }
+}
+
+.reasoning_header_expanded:hover {
+  border-radius: 0;
 }
 
 .reason {

--- a/frontend/src/components/message.tsx
+++ b/frontend/src/components/message.tsx
@@ -1,8 +1,9 @@
 import classNames from 'classnames';
-import React, { useMemo } from 'react';
+import React, { useState } from 'react';
 import styles from './message.module.css';
 import UserIcon from '../icons/account-circle.svg';
 import BotIcon from '../icons/logomark.svg';
+import ChevronIcon from '../icons/chevron.svg';
 
 export enum Role {
   User = 'User',
@@ -10,8 +11,10 @@ export enum Role {
 }
 
 export interface Message {
+  id?: string;
   role: Role;
   content: string;
+  reasoning?: string;
   time: string;
 }
 
@@ -36,14 +39,39 @@ const roleStyleMap: Record<Role, MessageStyle> = {
 };
 
 export const MessageComponent = ({ message }: MessageProps) => {
-  const { content, role } = message;
+  const { content, role, reasoning } = message;
 
-  const { class: roleClass, icon } = useMemo(() => roleStyleMap[role], [role]);
+  const { class: roleClass, icon } = roleStyleMap[role];
+
+  const [expanded, setExpanded] = useState(false);
 
   return (
     <div className={classNames(styles.container, roleClass)}>
-      <img src={icon} className={styles.iconStyle} />
-      <p className={styles.messageStyle}>{content}</p>
+      <div className={styles.message_container}>
+        <img src={icon} className={styles.iconStyle} />
+        <p className={styles.messageStyle}>{content}</p>
+      </div>
+      {role == Role.Bot && reasoning && (
+        <>
+          <div
+            className={classNames(styles.reasoning_header, {
+              [styles.reasoning_header_expanded]: expanded,
+            })}
+            role="button"
+            tabIndex={0}
+            onClick={() => setExpanded(!expanded)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                setExpanded(!expanded);
+              }
+            }}
+          >
+            How I came to this conclusion
+            <img className={styles.expandIcon} src={ChevronIcon} />
+          </div>
+          {expanded && <div className={styles.reason}>{reasoning}</div>}
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/server.ts
+++ b/frontend/src/server.ts
@@ -1,9 +1,12 @@
 export interface ChatMessageResponse {
-  message: string;
+  id?: string;
+  question?: string;
+  answer: string;
+  reasoning?: string;
 }
 
 function createChatMessageResponse(message: string): ChatMessageResponse {
-  return { message };
+  return { answer: message };
 }
 
 export const getResponse = async (
@@ -50,9 +53,6 @@ const callChatEndpoint = async (
       return response;
     })
     .then((response) => response.json())
-    .then((responseJson) => {
-      return createChatMessageResponse(responseJson);
-    })
     .catch((error) => {
       console.error('Error making REST call to /chat: ', error);
       return unhappyChatResponse;
@@ -63,9 +63,7 @@ export const getSuggestions = async (): Promise<string[]> => {
   return await fetch(`${process.env.BACKEND_URL}/suggestions`, {
     credentials: 'include',
   })
-    .then((response) => {
-      return response.json();
-    })
+    .then((response) => response.json())
     .catch((error) => {
       console.error('Error making REST call to /suggestions: ', error);
       return [];

--- a/frontend/src/useMessages.ts
+++ b/frontend/src/useMessages.ts
@@ -1,6 +1,11 @@
 import { useCallback, useState } from 'react';
 import { Message, Role } from './components/message';
-import { getResponse, getSuggestions, resetChat } from './server';
+import {
+  ChatMessageResponse,
+  getResponse,
+  getSuggestions,
+  resetChat,
+} from './server';
 
 const starterMessage: Message = {
   role: Role.Bot,
@@ -29,20 +34,29 @@ export const useMessages = (): UseMessagesHook => {
     }
   }, []);
 
-  const appendMessage = useCallback((message: string, role: Role) => {
-    setMessages((prevMessages) => [
-      ...prevMessages,
-      { role, content: message, time: new Date().toLocaleTimeString() },
-    ]);
-  }, []);
+  const appendMessage = useCallback(
+    (response: ChatMessageResponse, role: Role) => {
+      setMessages((prevMessages) => [
+        ...prevMessages,
+        {
+          role,
+          id: response.id,
+          content: response.answer,
+          reasoning: response.reasoning,
+          time: new Date().toLocaleTimeString(),
+        },
+      ]);
+    },
+    [],
+  );
 
   const sendMessage = useCallback(
     async (message: string) => {
-      appendMessage(message, Role.User);
+      appendMessage({ answer: message }, Role.User);
       setWaiting(true);
       const response = await getResponse(message);
       setWaiting(false);
-      appendMessage(response.message, Role.Bot);
+      appendMessage(response, Role.Bot);
       if (message !== 'healthcheck') {
         fetchSuggestions();
       }


### PR DESCRIPTION
## Description

Show the scratch pad reasoning alongside the answer.

![image](https://github.com/user-attachments/assets/93bfcdf1-7bba-4cb5-9ebd-cd3af150bfb8)

![image](https://github.com/user-attachments/assets/5426fc37-6d1f-4026-a44b-a58293d2203f)

## Changelog
- Return JSON rather than string for chat response. JSON includes id, question, answer and reasoning (scratch pad content as pretty printed json)
- Store chat responses in redis
- Add `/chat/{id}` endpoint to fetch chat response by id. Currently unused but provided for future and testing
- Add expandable section to message box to show returned reasoning
