### PR TITLE
Skip importing data at startup when already present

### DIFF
--- a/backend/src/directors/chat_director.py
+++ b/backend/src/directors/chat_director.py
@@ -11,7 +11,7 @@ from src.utils.dynamic_knowledge_graph import generate_dynamic_knowledge_graph
 from src.prompts import PromptEngine
 from src.supervisors import solve_all
 from src.utils import Config
-from src.utils.graph_db_utils import populate_db
+from src.utils.graph_db_utils import populate_db, is_db_populated
 from src.websockets.connection_manager import connection_manager
 
 logger = logging.getLogger(__name__)
@@ -62,6 +62,10 @@ async def question(question: str) -> ChatResponse:
 
 async def dataset_upload() -> None:
     dataset_file = "./datasets/bloomberg.csv"
+
+    if is_db_populated():
+        logger.info("Skipping database population as already has data")
+        return
 
     with open(dataset_file, 'r') as file:
         csv_data = [

--- a/backend/src/utils/graph_db_utils.py
+++ b/backend/src/utils/graph_db_utils.py
@@ -56,3 +56,16 @@ def populate_db(query, data) -> None:
         raise
     finally:
         driver.close()
+
+def is_db_populated() -> bool:
+    has_data = False
+    try:
+        db_response = execute_query("MATCH (n) RETURN n LIMIT 1")
+        if len(db_response) > 0:
+            has_data = True
+
+    except Exception as e:
+        logger.exception(f"Database connection failed: {e}")
+
+    finally:
+        return has_data


### PR DESCRIPTION
## Description

The sample data is imported on backend startup for each file save, when developing and watching the backend.
This adds logic to skip the import when there is already some data present.