### PR TITLE
FS-131 Fix chat area clipping

### DIFF
--- a/frontend/src/app.module.css
+++ b/frontend/src/app.module.css
@@ -14,7 +14,6 @@
   flex-direction: column;
   box-sizing: border-box;
   justify-content: center;
-  overflow: hidden;
 }
 
 .title {


### PR DESCRIPTION
## Description

Remove `overflow: hidden` on the chat area to prevent clipping of upload tooltip and input border

![image](https://github.com/user-attachments/assets/6065b1c7-d567-433b-8162-df8c062bcbea)

![image](https://github.com/user-attachments/assets/186c208f-7614-4fdf-90dc-086d818da933)

