### PR TITLE
WIP: FS-141: Improve intent agent prompt

### DIFF
--- a/backend/src/directors/chat_director.py
+++ b/backend/src/directors/chat_director.py
@@ -34,8 +34,7 @@ async def question(question: str) -> ChatResponse:
     update_session_chat(role="user", content=question)
     logger.info(f"Intent determined: {intent}")
 
-    questions = intent_json["questions"]
-    await solve_questions(questions if len(questions) > 0 else [intent_json["question"]])
+    await solve_questions(intent_json["questions"])
 
     current_scratchpad = get_scratchpad()
 
@@ -52,7 +51,7 @@ async def question(question: str) -> ChatResponse:
 
     final_answer = FinalAnswer()
     try:
-        final_answer = await __create_final_answer(question, intent_json)
+        final_answer = await __create_final_answer(question)
         update_session_chat(role="system", content=final_answer.message)
     except Exception as error:
         logger.error(f"Error during answer generation: {error}", error)
@@ -74,18 +73,13 @@ async def question(question: str) -> ChatResponse:
     return response
 
 
-async def __create_final_answer(question: str, intent_json: dict) -> FinalAnswer:
-    dataset = None
-    if intent_json['result_type'] == 'dataset':
-        # get the last DatastoreAgent result dataset from the scratchpad
-        datastore_agents = [answer for answer in get_scratchpad() if answer['agent_name'] == 'DatastoreAgent']
-        query_result = datastore_agents[-1]['result'] if datastore_agents else None
-        if query_result is not None:
-            dataset = query_result
+async def __create_final_answer(question: str) -> FinalAnswer:
+    datastore_agents = [scratch for scratch in get_scratchpad() if scratch['agent_name'] == 'DatastoreAgent']
+    query_result = datastore_agents[-1]['result'] if datastore_agents else None
 
     message = await get_answer_agent().create_answer(question)
 
-    return FinalAnswer(message, dataset)
+    return FinalAnswer(message, query_result)
 
 
 async def dataset_upload() -> None:

--- a/backend/src/prompts/templates/agent-selection-system-prompt.j2
+++ b/backend/src/prompts/templates/agent-selection-system-prompt.j2
@@ -1,13 +1,18 @@
-You job is to assign a task to an agent. You know that an Agent is a digital assistant like yourself that you can hand this work on to. You must choose only one agent from the below list of agents:
+Your job is to pick an agent to answer a question
 
+You know that an Agent is a digital assistant like yourself that you can hand this work on to.
+
+You will carefully select the agent based on the agent descriptions.
+You will check if the task meets any criteria listed in the agent description.
+You will provide a reason for your choice.
+
+If no agent is appropriate for the task, you will not pick one.
+
+You have the following agents to select from:
 {{ list_of_agents }}
 
-You must choose an agent from the list and give a reasoning for your choice.
+Reply with a single line of json with no additional formatting or markdown:
 
-Reply only in json with the following format:
+{ "agent_name": "exact string of the single agent to solve task chosen", "reasoning": "reasoning behind choosing the agent" }
 
-{
-
-    "agent_name": "exact string of the single agent to solve task chosen",
-    "reasoning": "reasoning behind choosing the agent"
-}
+{ "agent_name": "", "reasoning": "No agent is suitable for the task." }

--- a/backend/src/prompts/templates/create-answer-system-prompt.j2
+++ b/backend/src/prompts/templates/create-answer-system-prompt.j2
@@ -8,3 +8,4 @@ Some things to consider are listed below:
 - Only use information that relates to answering the question
 - If you cannot generate an answer to the users question using the provided information, you will recommend the user to look this up themselves.
 - The question may have been broken down into multiple parts with individual answers. Your task is to use all the information provided to answer the original question
+- When url citations are provided, include a statement that indicates the urls that were used as a reference with a link.

--- a/backend/src/prompts/templates/intent-system.j2
+++ b/backend/src/prompts/templates/intent-system.j2
@@ -1,17 +1,33 @@
-You are an expert in determining the intent behind a user's question, breaking down complex questions into multiple simpler questions and forming standalone questions based on context from chat history.
+You are an intent processing agent. Your role is to analyze user questions in the context of the conversation history and process questions by:
 
-You will be given a question and may also be provided with chat history which is to be used as context if provided.
+1. Question Clarification and Resolution
+* Examine the conversation history to resolve ambiguous references
+* Replace pronouns and unclear references with their specific antecedents
+* Maintain all relevant context from file names, company names, and specific details
+* Preserve the original meaning while making the question explicitly clear
 
-- First determine the user intent of the question by taking key points from the question and gaining context from the chat history.
-- Second
-  - if the question mentions csv, dataset or database the questions list should be an empty array
-  - else use your initiative to determine whether the question is complex enough split up and if it is then using the user intent try to split the question up into multiple questions with singular objectives.
+2. Question Decomposition (when needed)
+* Identify if a question contains multiple distinct information requests
+* Split compound questions into individual, atomic questions
+* Add temporal context only when explicitly mentioned
+* Ensure each sub-question can be answered independently
 
-Output your result in the following json format:
+Output Format:
+Your response must be a single line of json with no formatting or markdown.
+{"questions": []}
 
-{
-    "question": "string of the original question",
-    "user_intent": "string of the intent of the user's question",
-    "result_type": "string of the type of result expected, this will be either 'text' or 'dataset'",
-    "questions": array of singular objective questions or if the question mentions csv, dataset or database an empty array
-}
+"questions" is an array of clarified questions, where each question is fully contextualized.
+
+Guidelines:
+* Always use the most recent context from the conversation history
+* Maintain specific details like file names, company names, and dates
+* When splitting questions, ensure each sub-question contains full context
+* Only preserve temporal references that were explicitly mentioned
+* Do not add temporal context unless it was present in the original question or conversation history
+* Do not attempt to answer the questions, only process them
+* Each question in the array should be fully clarified and contextualized
+* Split questions only when multiple distinct pieces of information are requested
+* Consider whether a question truly needs to be split - don't force splitting when a single question would suffice
+* Maintain the original language style and terminology used in the question
+* For single questions, the array should contain one fully clarified question
+* For compound questions, the array should contain multiple clarified questions


### PR DESCRIPTION
## Description
https://scottlogic.atlassian.net/browse/FS-141

## Changelog
- Add more guidance to the intent prompt
- Change the output of the intent prompt to a single list of questions
- Allow agent selection prompt to not select an agent. This is necessary as when an agent fails to provide an answer the supervisor will add the failed agent to the exclusion list. When the agent selection prompt has a reduced list to chose from, it will pick anything even if the selected agent is not appropraite.
- Default to generalist agent when select-agent does not choose an agent.
