### PR TITLE
FS-97 Use the custom tooltips for file name button

### DIFF
--- a/frontend/src/components/fileUpload.module.css
+++ b/frontend/src/components/fileUpload.module.css
@@ -53,43 +53,6 @@
   height: 100%;
 }
 
-.tooltip {
-  position: absolute;
-  bottom: 130%;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 220px;
-  background-color: #333333;
-  color: #f2f2f2;
-  padding: 8px;
-  border-radius: 8px;
-  font-family: 'Roboto', sans-serif;
-  font-size: 14px;
-  line-height: 16px;
-  text-align: left;
-  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-  z-index: 10;
-}
-
-.tooltip p {
-  margin: 0 0 8px 0;
-}
-
-.tooltip p:last-child {
-  margin-bottom: 0;
-}
-
-.tooltip::after {
-  content: '';
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  border-width: 8px;
-  border-style: solid;
-  border-color: #333333 transparent transparent transparent;
-}
-
 @keyframes pulse {
   0%,
   100% {

--- a/frontend/src/components/fileUpload.tsx
+++ b/frontend/src/components/fileUpload.tsx
@@ -3,6 +3,7 @@ import styles from './fileUpload.module.css';
 import UploadIcon from '../icons/upload.svg';
 import UploadInProgressIcon from '../icons/upload-in-progress.svg';
 import CheckCircleIcon from '../icons/check-circle.svg';
+import { Tooltip } from './tooltip';
 
 interface FileUploaderProps {
   onFileUpload: (file: File) => Promise<void>;
@@ -60,7 +61,7 @@ export const FileUpload = ({
           disabled={disabled}
         />
       </label>
-      {showTooltip && <div className={styles.tooltip}>{tooltipContent}</div>}
+      {showTooltip && <Tooltip>{tooltipContent}</Tooltip>}
     </div>
   );
 };

--- a/frontend/src/components/tooltip.module.css
+++ b/frontend/src/components/tooltip.module.css
@@ -1,0 +1,36 @@
+.tooltip {
+  position: absolute;
+  bottom: 130%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 220px;
+  background-color: #333333;
+  color: #f2f2f2;
+  padding: 8px;
+  border-radius: 8px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 14px;
+  line-height: 16px;
+  text-align: left;
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  z-index: 10;
+}
+
+.tooltip p {
+  margin: 0 0 8px 0;
+}
+
+.tooltip p:last-child {
+  margin-bottom: 0;
+}
+
+.tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 8px;
+  border-style: solid;
+  border-color: #333333 transparent transparent transparent;
+}

--- a/frontend/src/components/tooltip.tsx
+++ b/frontend/src/components/tooltip.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import styles from './tooltip.module.css';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export const Tooltip = ({ children }: Props) => (
+  <div className={styles.tooltip}>{children}</div>
+);

--- a/frontend/src/components/uploadedFileDisplay.module.css
+++ b/frontend/src/components/uploadedFileDisplay.module.css
@@ -7,8 +7,15 @@
   box-sizing: border-box;
 }
 
+.uploadedFileTooltipContainer {
+  position: relative;
+  margin-right: 65px;
+  max-width: calc(100% - 65px);
+}
+
 .uploadedFile {
   font-size: 14px;
+  display: inline-block;
   color: var(--grey-900);
   background-color: var(--grey-200);
   padding: 8px 12px;
@@ -17,7 +24,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-right: 65px;
+  max-width: 100%;
 }
 
 .uploadedFile:hover {

--- a/frontend/src/components/uploadedFileDisplay.tsx
+++ b/frontend/src/components/uploadedFileDisplay.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './uploadedFileDisplay.module.css';
 import AttachmentIcon from '../icons/attachment.svg';
+import { Tooltip } from './tooltip';
 
 interface UploadedFileDisplayProps {
   fileName: string;
@@ -10,20 +11,32 @@ interface UploadedFileDisplayProps {
 export const UploadedFileDisplay = ({
   fileName,
   onClick,
-}: UploadedFileDisplayProps) => (
-  <div className={styles.uploadedFileContainer}>
-    <span
-      className={styles.uploadedFile}
-      role="button"
-      onClick={onClick}
-      title="Append the filename to the end of the message"
-    >
-      <img
-        src={AttachmentIcon}
-        alt="Attachment"
-        className={styles.attachmentIcon}
-      />
-      {fileName}
-    </span>
-  </div>
-);
+}: UploadedFileDisplayProps) => {
+  const [showTooltip, setShowTooltip] = useState<boolean>(false);
+
+  return (
+    <div className={styles.uploadedFileContainer}>
+      <div className={styles.uploadedFileTooltipContainer}>
+        <span
+          className={styles.uploadedFile}
+          role="button"
+          onClick={onClick}
+          onMouseEnter={() => setShowTooltip(true)}
+          onMouseLeave={() => setShowTooltip(false)}
+        >
+          <img
+            src={AttachmentIcon}
+            alt="Attachment"
+            className={styles.attachmentIcon}
+          />
+          {fileName}
+        </span>
+        {showTooltip && (
+          <Tooltip>
+            <p>Append the filename to the end of the message</p>
+          </Tooltip>
+        )}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

Use the same custom tooltip for the file name copy as for the file upload button

![image](https://github.com/user-attachments/assets/87186a54-9905-41d0-b84a-9e3f709c9053)


## Changelog
- Pull out existing tooltip code to new component
