### PR TITLE
FS-139 Generate DB schema to start up

### DIFF
--- a/backend/src/agents/datastore_agent.py
+++ b/backend/src/agents/datastore_agent.py
@@ -1,5 +1,8 @@
 import json
 import logging
+import os
+
+from dotenv import load_dotenv
 from src.llm.llm import LLM
 from src.utils.graph_db_utils import execute_query
 from src.prompts import PromptEngine
@@ -101,6 +104,19 @@ async def get_semantic_layer_cache(llm, model):
         return cache
     else:
         return cache
+
+async def initialize_semantic_layer():
+    try:
+        load_dotenv()
+        llm_name = os.getenv("DATASTORE_AGENT_LLM")
+        model_name = os.getenv("DATASTORE_AGENT_MODEL")
+
+        llm_instances = LLM.get_instances()
+        llm = llm_instances.get(llm_name)
+
+        await get_semantic_layer_cache(llm, model_name)
+    except Exception as e:
+        logger.exception(e)
 
 
 @chat_agent(

--- a/backend/src/agents/datastore_agent.py
+++ b/backend/src/agents/datastore_agent.py
@@ -9,7 +9,7 @@ from src.utils.log_publisher import LogPrefix, publish_log_info
 from src.agents.agent import chat_agent
 from src.agents.base_chat_agent import BaseChatAgent
 from src.agents.tool import tool, Parameter, ToolActionSuccess, ToolActionFailure
-from src.utils.semantic_layer_builder import get_semantic_layer
+from src.utils.semantic_layer_builder import get_semantic_layer, semantic_layer_ready
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +21,7 @@ cache = {}
 async def generate_cypher_query_core(
     question_intent, operation, question_params, aggregation, sort_order, timeframe, llm: LLM, model
 ) -> ToolActionSuccess | ToolActionFailure:
+    await semantic_layer_ready.wait()
     details_to_create_cypher_query = engine.load_prompt(
         "details-to-create-cypher-query",
         question_intent=question_intent,

--- a/backend/src/api/app.py
+++ b/backend/src/api/app.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 import json
 import logging.config
@@ -34,7 +35,8 @@ config = Config()
 async def lifespan(app: FastAPI):
     # start up
     try:
-        await dataset_upload()
+        logger.info("Starting dataset upload and semantic layer initialization.")
+        asyncio.create_task(dataset_upload())
     except Exception as e:
         logger.exception(f"Failed to populate database with initial data from file: {e}")
     yield

--- a/backend/src/directors/chat_director.py
+++ b/backend/src/directors/chat_director.py
@@ -1,9 +1,15 @@
+import asyncio
 from dataclasses import dataclass
 import json
 import logging
+import os
 from typing import Optional
 from uuid import uuid4
 
+from dotenv import load_dotenv
+
+from src.agents.datastore_agent import get_semantic_layer_cache
+from src.llm.llm import LLM
 from src.session.chat_response import update_session_chat_response_ids
 from src.utils.json import try_pretty_print
 from src.chat_storage_service import ChatResponse, store_chat_message
@@ -21,6 +27,7 @@ logger = logging.getLogger(__name__)
 config = Config()
 engine = PromptEngine()
 director_prompt = engine.load_prompt("chat_director")
+
 
 @dataclass
 class FinalAnswer:
@@ -43,11 +50,13 @@ async def question(question: str) -> ChatResponse:
             generated_figure = entry["result"]
             await connection_manager.send_chart({"type": "image", "data": generated_figure})
             clear_scratchpad()
-            return ChatResponse(id=str(uuid4()),
-                                question=question,
-                                answer="",
-                                dataset=None,
-                                reasoning=try_pretty_print(current_scratchpad))
+            return ChatResponse(
+                id=str(uuid4()),
+                question=question,
+                answer="",
+                dataset=None,
+                reasoning=try_pretty_print(current_scratchpad),
+            )
 
     final_answer = FinalAnswer()
     try:
@@ -59,11 +68,13 @@ async def question(question: str) -> ChatResponse:
 
     logger.info(f"final answer: {final_answer}")
 
-    response = ChatResponse(id=str(uuid4()),
-                            question=question,
-                            answer=final_answer.message or '',
-                            dataset=final_answer.dataset,
-                            reasoning=try_pretty_print(current_scratchpad))
+    response = ChatResponse(
+        id=str(uuid4()),
+        question=question,
+        answer=final_answer.message or "",
+        dataset=final_answer.dataset,
+        reasoning=try_pretty_print(current_scratchpad),
+    )
 
     store_chat_message(response)
     update_session_chat_response_ids(response.get("id"))
@@ -87,14 +98,27 @@ async def dataset_upload() -> None:
 
     if is_db_populated():
         logger.info("Skipping database population as already has data")
+        asyncio.create_task(initialize_semantic_layer())
         return
 
-    with open(dataset_file, 'r') as file:
-        csv_data = [
-            [entry for entry in line.strip('\n').split(",")]
-            for line in file
-        ]
+    with open(dataset_file, "r") as file:
+        csv_data = [[entry for entry in line.strip("\n").split(",")] for line in file]
 
     knowledge_graph_config = await generate_dynamic_knowledge_graph(csv_data)
 
     populate_db(knowledge_graph_config["cypher_query"], csv_data)
+    asyncio.create_task(initialize_semantic_layer())
+
+
+async def initialize_semantic_layer():
+    try:
+        load_dotenv()
+        llm_name = os.getenv("DATASTORE_AGENT_LLM")
+        model_name = os.getenv("DATASTORE_AGENT_MODEL")
+
+        llm_instances = LLM.get_instances()
+        llm = llm_instances.get(llm_name)
+
+        await get_semantic_layer_cache(llm, model_name)
+    except Exception as e:
+        logger.exception(e)

--- a/backend/src/directors/chat_director.py
+++ b/backend/src/directors/chat_director.py
@@ -2,14 +2,10 @@ import asyncio
 from dataclasses import dataclass
 import json
 import logging
-import os
 from typing import Optional
 from uuid import uuid4
 
-from dotenv import load_dotenv
-
-from src.agents.datastore_agent import get_semantic_layer_cache
-from src.llm.llm import LLM
+from src.agents.datastore_agent import initialize_semantic_layer
 from src.session.chat_response import update_session_chat_response_ids
 from src.utils.json import try_pretty_print
 from src.chat_storage_service import ChatResponse, store_chat_message
@@ -109,16 +105,3 @@ async def dataset_upload() -> None:
     populate_db(knowledge_graph_config["cypher_query"], csv_data)
     asyncio.create_task(initialize_semantic_layer())
 
-
-async def initialize_semantic_layer():
-    try:
-        load_dotenv()
-        llm_name = os.getenv("DATASTORE_AGENT_LLM")
-        model_name = os.getenv("DATASTORE_AGENT_MODEL")
-
-        llm_instances = LLM.get_instances()
-        llm = llm_instances.get(llm_name)
-
-        await get_semantic_layer_cache(llm, model_name)
-    except Exception as e:
-        logger.exception(e)

--- a/backend/src/utils/semantic_layer_builder.py
+++ b/backend/src/utils/semantic_layer_builder.py
@@ -2,6 +2,9 @@ from src.utils.graph_db_utils import execute_query
 import logging
 from src.prompts import PromptEngine
 import json
+import asyncio
+
+semantic_layer_ready = asyncio.Event()
 
 logger = logging.getLogger(__name__)
 
@@ -20,14 +23,13 @@ neo4j_relationship_property_prompt = engine.load_prompt(
     "neo4j-property-intent-prompt", neo4j_graph_why_prompt=neo4j_graph_why_prompt
 )
 
-neo4j_node_property_prompt = engine.load_prompt(
-    "neo4j-node-property", neo4j_graph_why_prompt=neo4j_graph_why_prompt
-)
+neo4j_node_property_prompt = engine.load_prompt("neo4j-node-property", neo4j_graph_why_prompt=neo4j_graph_why_prompt)
 relationship_query = engine.load_prompt("relationships-query")
 
 neo4j_relationships_understanding_prompt = engine.load_prompt(
     "neo4j-relationship-understanding", neo4j_graph_why_prompt=neo4j_graph_why_prompt
 )
+
 
 async def get_semantic_layer(llm, model):
     finalised_graph_structure = {"nodes": {}, "properties": {}}
@@ -39,91 +41,94 @@ async def get_semantic_layer(llm, model):
     relationships_dict = {}
 
     # Convert nodes
-    for node in payload['nodes']:
-        nodes.append({
-            "cypher_representation": f"(:{node['name']})",
-            "label": node['name'],
-            "indexes": node.get('indexes', []),
-            "constraints": node.get('constraints', [])
-        })
+    for node in payload["nodes"]:
+        nodes.append(
+            {
+                "cypher_representation": f"(:{node['name']})",
+                "label": node["name"],
+                "indexes": node.get("indexes", []),
+                "constraints": node.get("constraints", []),
+            }
+        )
 
     # Convert relationships
-    for relationship in payload['relationships']:
-        start_node = relationship[0]['name']
+    for relationship in payload["relationships"]:
+        start_node = relationship[0]["name"]
         relationship_type = relationship[1]
-        end_node = relationship[2]['name']
+        end_node = relationship[2]["name"]
         path = f"(:{start_node})-[:{relationship_type}]->(:{end_node})"
 
         if relationship_type not in relationships_dict:
             relationships_dict[relationship_type] = {
                 "cypher_representation": f"[:{relationship_type}]",
                 "type": relationship_type,
-                "paths": []
+                "paths": [],
             }
 
-        relationships_dict[relationship_type]["paths"].append({
-            "path": path,
-            "detail": ""
-        })
+        relationships_dict[relationship_type]["paths"].append({"path": path, "detail": ""})
     # Convert relationships_dict to a list
     relationships = list(relationships_dict.values())
 
-    finalised_graph_structure = {
-        "nodes": nodes,
-        "relationships": relationships
-    }
+    finalised_graph_structure = {"nodes": nodes, "relationships": relationships}
     json.dumps(finalised_graph_structure)
 
-    await enrich_relationships(llm, model, finalised_graph_structure)
-    await enrich_nodes(llm, model, finalised_graph_structure)
-    await enriched_rel_properties(llm, model, finalised_graph_structure)
-    await enrich_nodes_properties(llm, model, finalised_graph_structure)
-
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(enrich_relationships(llm, model, finalised_graph_structure))
+        tg.create_task(enrich_nodes(llm, model, finalised_graph_structure))
+        tg.create_task(enriched_rel_properties(llm, model, finalised_graph_structure))
+        tg.create_task(enrich_nodes_properties(llm, model, finalised_graph_structure))
+    semantic_layer_ready.set()
+    logger.info("Semantic layer initialized successfully.")
     return finalised_graph_structure
 
+
 async def enrich_relationships(llm, model, finalised_graph_structure):
-    relationships = finalised_graph_structure['relationships']
+    relationships = finalised_graph_structure["relationships"]
     enriched_relationships_list = []
 
     for relationship in relationships:
-        enriched_relationship = await llm.chat(model, neo4j_relationships_understanding_prompt, str(relationship),
-                                               return_json=True)
+        enriched_relationship = await llm.chat(
+            model, neo4j_relationships_understanding_prompt, str(relationship), return_json=True
+        )
         enriched_relationships_list.append(json.loads(enriched_relationship))
 
-        finalised_graph_structure['relationships'] = enriched_relationships_list
+        finalised_graph_structure["relationships"] = enriched_relationships_list
     logger.debug(f"finalised graph structure with enriched relationships: {finalised_graph_structure}")
 
+
 async def enrich_nodes(llm, model, finalised_graph_structure):
-        neo4j_data = finalised_graph_structure['nodes']
-        print(f"neo4j data: {neo4j_data}")
-        enriched_nodes = await llm.chat(model, neo4j_nodes_understanding_prompt, str(neo4j_data), return_json=True)
-        enriched_nodes = json.loads(enriched_nodes)
-        json.dumps(enriched_nodes)
-        finalised_graph_structure['nodes'] = enriched_nodes
-        logger.debug(f"finalised graph structure: {finalised_graph_structure}")
-        print(f"finalised_graph_structure with nodes: {finalised_graph_structure}")
+    neo4j_data = finalised_graph_structure["nodes"]
+    print(f"neo4j data: {neo4j_data}")
+    enriched_nodes = await llm.chat(model, neo4j_nodes_understanding_prompt, str(neo4j_data), return_json=True)
+    enriched_nodes = json.loads(enriched_nodes)
+    json.dumps(enriched_nodes)
+    finalised_graph_structure["nodes"] = enriched_nodes
+    logger.debug(f"finalised graph structure: {finalised_graph_structure}")
+    print(f"finalised_graph_structure with nodes: {finalised_graph_structure}")
+
 
 async def enriched_rel_properties(llm, model, finalised_graph_structure):
     properties_result = execute_query(relationship_property_query)
     rel_properties_neo4j = properties_result[0]
     cleaned_rel_properties = []
 
-    for rel_property in rel_properties_neo4j['relProperties']:
-        cleaned_properties = [prop for prop in rel_property['properties'] if prop['name'] is not None]
+    for rel_property in rel_properties_neo4j["relProperties"]:
+        cleaned_properties = [prop for prop in rel_property["properties"] if prop["name"] is not None]
         if cleaned_properties:
-            rel_property['properties'] = cleaned_properties
+            rel_property["properties"] = cleaned_properties
             cleaned_rel_properties.append(rel_property)
 
-    rel_properties_neo4j = {'relProperties': cleaned_rel_properties}
+    rel_properties_neo4j = {"relProperties": cleaned_rel_properties}
     json.dumps(rel_properties_neo4j)
 
-    enriched_rel_properties = await llm.chat(model, neo4j_relationship_property_prompt, str(rel_properties_neo4j),
-                                            return_json=True)
+    enriched_rel_properties = await llm.chat(
+        model, neo4j_relationship_property_prompt, str(rel_properties_neo4j), return_json=True
+    )
     enriched_rel_properties = json.loads(enriched_rel_properties)
 
     # Merge properties
     for new_rel in enriched_rel_properties["relProperties"]:
-        #FS-67 - This change was done as relType is unavailable here for mistral.
+        # FS-67 - This change was done as relType is unavailable here for mistral.
         relationship_type = new_rel.get("relType", None)
         if relationship_type is None:
             continue  # Skip if there's no relationship type specified
@@ -137,17 +142,20 @@ async def enriched_rel_properties(llm, model, finalised_graph_structure):
 
     logger.debug(f"finalised graph structure with enriched properties: {finalised_graph_structure}")
 
+
 async def enrich_nodes_properties(llm, model, finalised_graph_structure):
     node_properties_neo4j_result = execute_query(node_property_query)
     node_properties_neo4j = node_properties_neo4j_result[0]
     filtered_payload = {
-        'nodeProperties': [
-            node for node in node_properties_neo4j['nodeProperties']
-            if all(prop['data_type'] is not None and prop['name'] is not None for prop in node['properties'])
+        "nodeProperties": [
+            node
+            for node in node_properties_neo4j["nodeProperties"]
+            if all(prop["data_type"] is not None and prop["name"] is not None for prop in node["properties"])
         ]
     }
-    enriched_node_properties = await llm.chat(model, neo4j_node_property_prompt, str(filtered_payload),
-                                            return_json=True)
+    enriched_node_properties = await llm.chat(
+        model, neo4j_node_property_prompt, str(filtered_payload), return_json=True
+    )
     enriched_node_properties = json.loads(enriched_node_properties)
 
     for new_node in enriched_node_properties["nodeProperties"]:


### PR DESCRIPTION
## Description
Changed the dataset upload and semantic layer generation to execute as background tasks during app start up.

## Changelog
- Implemented dataset upload as a background task triggered at app start up 
- Changed the semantic layer generation to run as a background task upon successful dataset upload
- Used an Event in the datastore_agent to flag the readiness of the semantic layer, ensuring no actions proceed until the layer is fully prepped
- Changed semantic layer generation to be asynchronous
